### PR TITLE
Fix typo

### DIFF
--- a/docs/aws/services/rds-pricing.md
+++ b/docs/aws/services/rds-pricing.md
@@ -1,6 +1,6 @@
 title: RDS Pricing | Cloud Cost Handbook
 
-[Amazon EC2 Pricing Page](https://aws.amazon.com/rds/pricing/){ .md-button }
+[Amazon RDS Pricing Page](https://aws.amazon.com/rds/pricing/){ .md-button }
 
 ## Summary
 


### PR DESCRIPTION
The RDS pricing link text says EC2, but the link target is correct.